### PR TITLE
Add lang=scss to style script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simple and clean calendar written in Vue.js. See it in action [here](https://cod
 ## Usage
 Import styles in your .vue file:
 
-    <style src="vuelendar/scss/vuelendar.scss"></style>
+    <style src="vuelendar/scss/vuelendar.scss" lang="scss"></style>
 
 Register components:
 


### PR DESCRIPTION
I was unable to get the project to build without specifying the lang=scss attribute on the style tag. Adding this lang attribute allowed me to import vuelendar styles