### PR TITLE
Remove duplicate 'use in template' from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,6 @@ Use in template:
       v-model="date"
     />
 
-Use in template:
-
-    <v-range-selector
-      :start-date.sync="range.start"
-      :end-date.sync="range.end"
-    />
-
-    <v-day-selector
-      v-model="date"
-    />
-
 ## Disabling dates
 
 Vuelendar allows two ways for disabling dates.


### PR DESCRIPTION
the 'use in template' instructions on the README were duplicated, removed one of these duplicated instances.